### PR TITLE
重构

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-.idea
+.idea/
+__pycache__/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # Seed
 
-!!seed can get world seed
+!!seed to get world seed.
+
+## Preview
 
 ![image](https://user-images.githubusercontent.com/106148777/221347169-1764fb31-db0c-40e5-82cf-77c1915a638c.png)
 
+## Configure
 
-(yes, a very simple plugin
+`config/seed/config.json`
+- `command`: Command to get seed in console
+- `parser`: Parser for the command result
+
+The default configuration already supports most server software (without plugin/mods).
+
+## More
+
+This plugn was inspired by [`MCDReforged/Seed`](https://github.com/MCDReforged/Seed)

--- a/lang/en_us.yml
+++ b/lang/en_us.yml
@@ -1,4 +1,6 @@
 seed:
-  help_msg: Get world seed quickly!
-  get_seed: 'Seed:'
+  help_msg: Get world seed
+  get_seed: 'Seed: '
   copy_to_clipboard: Click to copy to clipboard
+  failed: Failed to get seed
+  

--- a/lang/zh_cn.yml
+++ b/lang/zh_cn.yml
@@ -1,4 +1,6 @@
 seed:
-  help_msg: 更快速的获取服务器种子！
-  get_seed: 服务器种子：
+  help_msg: 获取世界种子
+  get_seed: 种子：
   copy_to_clipboard: 点击复制到剪贴板
+  failed: 无法获取种子
+  

--- a/mcdreforged.plugin.json
+++ b/mcdreforged.plugin.json
@@ -1,8 +1,8 @@
 {
     "id": "seed",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "name": "Seed",
-    "description": "Get world seed quickly!",
+    "description": "Get world seed without op permission.",
     "author": [
         "OptiJava"
     ],


### PR DESCRIPTION
- 改进提示和简介：MCDR 并不能帮助玩家「更快」地获取种子，`/seed` 明显更快
- 在插件加载时就获取种子，不要等玩家触发命令
- 用 `0` 作为种子未获取状态是不对的，因为种子可以为 `0`
- 用 `source.reply`，而不是广播给所有玩家
- 允许用户自定义获取种子的指令和格式
- 更清晰的 README